### PR TITLE
Bump memory limit

### DIFF
--- a/k8s/backboard.yaml
+++ b/k8s/backboard.yaml
@@ -81,7 +81,7 @@ spec:
             limits:
               # Needs more CPU and memory when bootstrapping.
               cpu: "2"
-              memory: "512Mi"
+              memory: "768Mi"
           volumeMounts:
             - mountPath: "/secrets"
               name: secrets


### PR DESCRIPTION
Bootstrapping has been very memory hungry recently and we started
hitting this limit. Let's bump it by 50% in order to improve the
stability of the service.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/backboard/3)
<!-- Reviewable:end -->
