### PR TITLE
Show release tags from all branches

### DIFF
--- a/server.go
+++ b/server.go
@@ -465,12 +465,20 @@ func (s *server) serveBoard(w http.ResponseWriter, r *http.Request) error {
 				backportStatus = "◷"
 			}
 		}
-		if cIdx, backported := re.branchCommits[branch].messageIDs[c.MessageID()]; backported {
-			backportCommit := re.branchCommits[branch].commits[cIdx]
-			oldestTags = append(oldestTags, backportCommit.oldestTag)
-			// TODO(benesch): redundant. which to keep?
+		// TODO(benesch): redundant. which to keep?
+		if _, backported := re.branchCommits[branch].messageIDs[c.MessageID()]; backported {
 			backportStatus = "✓"
-
+		}
+		// Get tags from all release branches. not just the currently selected
+		// one. This makes it easier for CS and TSE to know whether a commit
+		// has been released yet.
+		for _, releaseBranch := range re.releaseBranches {
+			if cIdx, backported := re.branchCommits[releaseBranch].messageIDs[c.MessageID()]; backported {
+				backportCommit := re.branchCommits[releaseBranch].commits[cIdx]
+				if backportCommit.oldestTag != "" {
+					oldestTags = append(oldestTags, backportCommit.oldestTag)
+				}
+			}
 		}
 		acommits = append(acommits, acommit{
 			commit:         c,


### PR DESCRIPTION
This makes it easier to see all the releases that have a particular
backport commit.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/backboard/9)
<!-- Reviewable:end -->
