### PR TITLE
Tweak readiness probe values

### DIFF
--- a/k8s/backboard.yaml
+++ b/k8s/backboard.yaml
@@ -69,7 +69,11 @@ spec:
               path: /healthz
               port: http
           readinessProbe:
-            failureThreshold: 3
+            initialDelaySeconds: 600
+            periodSeconds: 30
+            successThreshold: 1
+            timeoutSeconds: 5
+            failureThreshold: 10
             httpGet:
               path: /healthz?ready=1
               port: http


### PR DESCRIPTION
This PR tweaks the following readiness probe values:

* `initialDelaySeconds` is set to 10 minutes to give the initial `git clone` more time. It usually takes less than 5 minutes.
* `periodSeconds` is set to 30 seconds to give more time between checks.
* `timeoutSeconds` is set to 5 seconds to match the in-app timeout.
* `failureThreshold` is set 10, to allow extra 300 seconds (10 * 30 of `periodSeconds`) before declaring a failure.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/backboard/12)
<!-- Reviewable:end -->
