### PR TITLE
Simplify secrets, reflect current deployment

### DIFF
--- a/k8s/backboard.yaml
+++ b/k8s/backboard.yaml
@@ -1,11 +1,6 @@
 # Create secrets with
 # kubectl create secret generic backboard-secrets \
-#   --from-file=ca.crt \
-#   --from-file=client.backboard.crt \
-#   --from-file=client.backboard.key \
-#   --from-literal=DB_USER=xyzzy \
-#   --from-literal=DB_ADDR=xyzzy:26257 \
-#   --from-literal=DB_NAME=xyzzy \
+#   --from-literal=DB_URL=url \
 #   --from-literal=BACKBOARD_GITHUB_TOKEN=xyzzy
 apiVersion: apps/v1
 kind: Deployment
@@ -33,20 +28,10 @@ spec:
           imagePullPolicy: Always
           name: backboard
           env:
-            - name: DB_USER
+            - name: DB_URL
               valueFrom:
                 secretKeyRef:
-                  key: DB_USER
-                  name: backboard-secrets
-            - name: DB_ADDR
-              valueFrom:
-                secretKeyRef:
-                  key: DB_ADDR
-                  name: backboard-secrets
-            - name: DB_NAME
-              valueFrom:
-                secretKeyRef:
-                  key: DB_NAME
+                  key: DB_URL
                   name: backboard-secrets
             - name: BACKBOARD_GITHUB_TOKEN
               valueFrom:
@@ -56,8 +41,8 @@ spec:
           command: [
             "backboard",
             "--bind", "0.0.0.0:80",
-            "--conn", "postgres://$(DB_USER):$(DB_PASSWORD)@$(DB_ADDR)/$(DB_NAME)?sslmode=verify-full&sslrootcert=/secrets/ca.crt",
-            "--branch", "release-21.1",
+            "--conn", "$(DB_URL)",
+            "--branch", "release-23.1",
           ]
           ports:
             - containerPort: 80
@@ -81,14 +66,11 @@ spec:
             requests:
               # Fairly minimal steady-state requirements.
               cpu: "100m"
-              memory: "256Mi"
+              memory: "512Mi"
             limits:
               # Needs more CPU and memory when bootstrapping.
               cpu: "2"
-              memory: "768Mi"
-          volumeMounts:
-            - mountPath: "/secrets"
-              name: secrets
+              memory: "1Gi"
       terminationGracePeriodSeconds: 30
       volumes:
         - name: secrets


### PR DESCRIPTION
Previously, the database sever required using a certificate, what required the certificate be a separate secret entry.

After switching to serverless, we we can just copy the DB URL from the UI and use it as a secret.

This PR also updates some values that changed in the current deployment.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/cockroachdb/backboard/13)
<!-- Reviewable:end -->
