### PR TITLE
Use `git clone --filter=blob:none` for faster clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ gcloud container clusters get-credentials prime --region us-east4 --project cock
     BACKBOARD_GITHUB_TOKEN=$token \
       ./backboard \
         --conn="postgresql://root@127.0.0.1:26257/backboard?sslmode=disable" \
-        --branch=release-21.1
+        --branch=release-23.1
     ```
 1. It will take quite a while for the first bootstrap to happen.
 1. Run backboard
@@ -42,6 +42,6 @@ gcloud container clusters get-credentials prime --region us-east4 --project cock
     BACKBOARD_GITHUB_TOKEN=$token \
       ./backboard --bind=0.0.0.0:3333 \
         --conn="postgresql://root@127.0.0.1:26257/backboard?sslmode=disable" \
-        --branch=release-21.1
+        --branch=release-23.1
     ```
 1. Open http://localhost:3333 in browser.

--- a/backboard.go
+++ b/backboard.go
@@ -24,10 +24,8 @@ var repos = []repo{
 
 func main() {
 	if err := run(os.Args); err != nil {
-		fmt.Fprintf(os.Stderr, "fatal: %s\n", err)
-		os.Exit(1)
+		log.Fatalf("fatal: %s\n", err)
 	}
-	os.Exit(0)
 }
 
 func run(args []string) error {
@@ -42,10 +40,13 @@ func run(args []string) error {
 		flags.PrintDefaults()
 		return err
 	}
-
 	if *connString == "" {
 		flags.PrintDefaults()
 		return errors.New("--conn is required")
+	}
+	if *branch == "" {
+		flags.PrintDefaults()
+		return errors.New("--branch flag is required")
 	}
 
 	githubToken := os.Getenv("BACKBOARD_GITHUB_TOKEN")
@@ -90,11 +91,6 @@ func run(args []string) error {
 		}
 
 		return syncAll(ctx, ghClient, db)
-	}
-
-	if *branch == "" {
-		flags.PrintDefaults()
-		return errors.New("--branch flag is required")
 	}
 
 	// Configure the HTTP handler with just /healthz until bootstrapped.

--- a/state.go
+++ b/state.go
@@ -271,7 +271,7 @@ type commit struct {
 	body       string
 	merge      bool
 	// oldestTag is the oldest release tag that contains this commit.
-	oldestTag  string
+	oldestTag string
 }
 
 func (c commit) SHA() sha {
@@ -602,7 +602,11 @@ func bootstrap(ctx context.Context, db *sql.DB) error {
 		url, path := repos[i].url(), repos[i].path()
 		if _, err := os.Stat(path); os.IsNotExist(err) {
 			log.Printf("cloning %s into %s", repos[i], path)
-			if err := spawn("git", "clone", "--mirror", url, path); err != nil {
+			if err := spawn("git", "clone", "--filter=blob:none", "--mirror", url, path); err != nil {
+				return err
+			}
+			// Do not run `git gc` automatically
+			if err := spawn("git", "config", "--global", "gc.auto", "0"); err != nil {
 				return err
 			}
 		} else if err != nil {


### PR DESCRIPTION
After reading
https://github.blog/2020-12-21-get-up-to-speed-with-partial-clone-and-shallow-clone/ I discovered there is a way to clone a repo without cloning the blobs (file contents). The resulted clone still contain all metadata we need for backboard operations. Subsequent `git fetch --tags` commands will not pull any blobs, so they will be faster as well.

"On my laptop" the operation went from 3.5 minutes to 20 seconds.

Part of: DEVINF-656